### PR TITLE
Disable http2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-alpine
+FROM node:12-alpine
 
 MAINTAINER PRX <sysadmin@prx.org>
 LABEL org.prx.app="yes"

--- a/config.js
+++ b/config.js
@@ -18,7 +18,7 @@
         baseAppUrl: "",
         port: 8061,
         relativeStaticUrl: "/s",
-        // use_http2: true,
+        DISABLE_HTTP2: true,
         DEBUG: false,
 
         SPDY_AGENT_DEFAULT_PORT: 443,
@@ -40,8 +40,8 @@
 
         // Do not cache response in htmlparser with these status codes.
         TEMP_HTTP_ERROR_CODES: [
-            408, 
-            418, 
+            408,
+            418,
             429
             // 5xx included in logic.
         ],
@@ -74,7 +74,7 @@
 
         T: {
             text_html: "text/html",
-            maybe_text_html: "maybe_text_html",            
+            maybe_text_html: "maybe_text_html",
             javascript: "application/javascript",
             safe_html: "text/x-safe-html",
             image_jpeg: "image/jpeg",
@@ -164,7 +164,7 @@
         },
 
         FEATURES: [ // feature policy: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy#Directives
-            'ambient-light-sensor', 'autoplay', 'accelerometer', 'camera', 'display-capture', 'document-domain', 'encrypted-media', 
+            'ambient-light-sensor', 'autoplay', 'accelerometer', 'camera', 'display-capture', 'document-domain', 'encrypted-media',
             'fullscreen', 'geolocation', 'gyroscope', 'magnetometer', 'microphone', 'midi', 'payment', 'picture-in-picture',
             'speaker', 'sync-xhr', 'usb', 'wake-lock', 'vr', 'xr', 'vr / xr'
         ],
@@ -412,7 +412,7 @@
         } else {
             baseAppUrlForAgent = config.baseAppUrl;
         }
-        
+
         config.USER_AGENT = "Iframely/" + version + " (+" + (baseAppUrlForAgent || 'https://github.com/itteco/iframely') + ")";
     }
 


### PR DESCRIPTION
as per https://github.com/itteco/iframely/issues/275 set `DISABLE_HTTP2: true` to get requests to work instead of timing out.