### PR TITLE
config: add allowedOrigins

### DIFF
--- a/config.local.js
+++ b/config.local.js
@@ -7,7 +7,12 @@
           ],
           params: {
               access_token: process.env.OEMBED_ACCESS_TOKEN
-          }
+          },
+          allowedOrigins: [
+              "*.pri.org",
+              "*-pri9.pantheonsite.io",
+              "pri9.lndo.site"
+          ]
         }]
     };
 


### PR DESCRIPTION
Adds PRI.org production and development domains to `allowedOrigins`.